### PR TITLE
Fix vagrant fs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "./", "/home/vagrant/go/src/github.com/phzfi/RIC/"
+  config.vm.synced_folder "./", "/home/vagrant/go/phzfi/RIC/"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "./", "/home/vagrant/go/github.com/phzfi/RIC/"
+  config.vm.synced_folder "./", "/home/vagrant/go/src/github.com/phzfi/RIC/"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/vagrant_setup.sh
+++ b/vagrant_setup.sh
@@ -5,13 +5,10 @@ sudo apt-get install -y golang-go dpkg-dev build-essential
 echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.bashrc
 export GOPATH=/home/vagrant/go
 chown -R vagrant:vagrant /home/vagrant/go
-go get github.com/joonazan/imagick/imagick
-go get gopkg.in/tylerb/graceful.v1
-go install github.com/phzfi/RIC/server
 
-sudo mv /home/vagrant/go/src/github.com/phzfi/RIC/server/testresults/ testresults
-sudo ln -s /home/vagrant/testresults/ /home/vagrant/go/src/github.com/phzfi/RIC/server/testresults
-sudo chown -R vagrant:vagrant /home/vagrant/testresults/
+go get github.com/phzfi/RIC/...
+sudo rm -rf /home/vagrant/go/src/github.com/phzfi
+sudo mv /home/vagrant/go/phzfi /home/vagrant/go/src/github.com
 
 cd /tmp
 mkdir imagemagick

--- a/vagrant_setup.sh
+++ b/vagrant_setup.sh
@@ -5,6 +5,9 @@ sudo apt-get install -y golang-go dpkg-dev build-essential
 echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.bashrc
 export GOPATH=/home/vagrant/go
 chown -R vagrant:vagrant /home/vagrant/go
+go get github.com/joonazan/imagick/imagick
+go get gopkg.in/tylerb/graceful.v1
+go install github.com/phzfi/RIC/server
 
 sudo mv /home/vagrant/go/src/github.com/phzfi/RIC/server/testresults/ testresults
 sudo ln -s /home/vagrant/testresults/ /home/vagrant/go/src/github.com/phzfi/RIC/server/testresults

--- a/vagrant_setup.sh
+++ b/vagrant_setup.sh
@@ -5,7 +5,6 @@ sudo apt-get install -y golang-go dpkg-dev build-essential
 echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.bashrc
 export GOPATH=/home/vagrant/go
 chown -R vagrant:vagrant /home/vagrant/go
-go get github.com/phzfi/RIC/...
 
 sudo mv /home/vagrant/go/src/github.com/phzfi/RIC/server/testresults/ testresults
 sudo ln -s /home/vagrant/testresults/ /home/vagrant/go/src/github.com/phzfi/RIC/server/testresults


### PR DESCRIPTION
Vagrant setup no longer creates two source directories and now creates working go file structure out of the box. Synchronized folder is "~/go/src/github.com/phzfi/RIC/" in virtual machine. Got rid of testresults-folder linking, which caused go testing to not find test images.