### PR TITLE
Wrong mime type

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -61,6 +61,7 @@ func (h *MyHandler) ServeHTTP(ctx *fasthttp.RequestCtx) {
 			img := images.NewImage()
 			img.PingImageBlob(blob)
 			ctx.SetContentType("image/" + img.GetImageFormat())
+			img.Destroy()
 
 			ctx.Write(blob)
 			logging.Debug("Blob returned")

--- a/server/main.go
+++ b/server/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/joonazan/imagick/imagick"
 	"github.com/phzfi/RIC/server/cache"
 	"github.com/phzfi/RIC/server/logging"
+	"github.com/phzfi/RIC/server/images"
 	"github.com/phzfi/RIC/server/ops"
 	"github.com/valyala/fasthttp"
 	"log"
@@ -55,6 +56,12 @@ func (h *MyHandler) ServeHTTP(ctx *fasthttp.RequestCtx) {
 			ctx.NotFound()
 			logging.Debug(err)
 		} else {
+			// ping blob to avoid reading whole image into memory
+			// and set right content-type response header
+			img := images.NewImage()
+			img.PingImageBlob(blob)
+			ctx.SetContentType("image/" + img.GetImageFormat())
+
 			ctx.Write(blob)
 			logging.Debug("Blob returned")
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -135,3 +135,32 @@ func TestGetLiquid(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Test for right content-type request header
+func TestMIMEtype(t *testing.T) {
+	s, ln, srverr := startServer()
+	defer stopServer(s, ln, srverr)
+	response := fasthttp.AcquireResponse()
+	request := fasthttp.AcquireRequest()
+	cases := []string{"01.jpg", "01.png",	"01.webp", "01.tiff", "01.bmp",	"01.gif"}
+	folder := "testimages/server/"
+
+	for _, c := range cases {
+		request.SetRequestURI(fmt.Sprintf("http://localhost:%d/", port) + folder + c)
+		fasthttp.Do(request, response)
+		MIME := string(response.Header.ContentType())
+
+		img := images.NewImage()
+		img.FromBlob(response.Body())
+		expected := "image/" + img.GetImageFormat()
+
+		if MIME != expected {
+			t.Fatal("Server returned: " + MIME)
+		}
+		request.Reset()
+		response.Reset()
+		img.Destroy()
+	}
+	fasthttp.ReleaseRequest(request)
+	fasthttp.ReleaseResponse(response)
+}


### PR DESCRIPTION
Server now sets correct content-type in response header such as "image/JPEG", image/WEBP" instead of previous "text/plain". Implemented tests for image types JPEG, PNG, WEBP, GIF, TIFF and BMP.