### PR TITLE
fixed imagemagick imports

### DIFF
--- a/server/images/image.go
+++ b/server/images/image.go
@@ -2,7 +2,7 @@ package images
 
 import (
 	"errors"
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 	"strings"
 )
 

--- a/server/images/loadimage_test.go
+++ b/server/images/loadimage_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 	"path/filepath"
 	"testing"
 )

--- a/server/images/resize.go
+++ b/server/images/resize.go
@@ -1,7 +1,7 @@
 package images
 
 import (
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 )
 
 func (img Image) Resize(w, h int) error {

--- a/server/images/testutils.go
+++ b/server/images/testutils.go
@@ -3,7 +3,7 @@ package images
 import (
 	"errors"
 	"fmt"
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 	"path/filepath"
 )
 

--- a/server/main.go
+++ b/server/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 	"github.com/phzfi/RIC/server/cache"
 	"github.com/phzfi/RIC/server/logging"
 	"github.com/phzfi/RIC/server/images"


### PR DESCRIPTION
Fixed all imagemagick imports to working ones. A simple vagrant provision was needed to get the installation working as there was some issues with permissions.