### PR TITLE
fix test data race when launching go routines inside for loop

### DIFF
--- a/server/operator/operator_test.go
+++ b/server/operator/operator_test.go
@@ -78,7 +78,8 @@ func TestDenyIdenticalOperations(t *testing.T) {
 	c := make(chan bool, len(operations))
 
 	// Launch operations simultaneously
-	for _, ops := range operations {
+	for i := range operations {
+		ops := operations[i]
 		go func() {
 			_, _ = operator.GetBlob(ops...)
 			c <- true


### PR DESCRIPTION
Fix data race in TestDenyIdenticalOperations when launching go routines inside for loop. Variable "ops" is now declared inside body of the loop, so that it is not shared between the iterations.