### PR TITLE
Use larger test image to ensure that in the test PingImage is faster than FromFile.

### DIFF
--- a/server/ops/ping_image_test.go
+++ b/server/ops/ping_image_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 	"time"
 	"github.com/phzfi/RIC/server/images"
+	"github.com/phzfi/RIC/server/logging"
 	"fmt"
 )
 
 
 func TestPingRoots(t *testing.T) {
+	logging.Debugf("Testing PingRoots...")
 
 	is := MakeImageSource()
 	err := is.AddRoot("../")
@@ -42,7 +44,8 @@ func TestPingRoots(t *testing.T) {
 		t.Fatal(err)
 	}
 	t3 := time.Now().Sub(t0)
-
+	
+	logging.Debugf("searchRoots #1: %v, pingRoots: %v, searchRoots #2: %v", t1, t2, t3)
 	if t1 < t2 {
 		t.Fatal(fmt.Sprintf("pingRoots is slower than searchRoots! pingRoots: %v, searchRoots: %v", t2, t1))
 	}

--- a/server/ops/ping_image_test.go
+++ b/server/ops/ping_image_test.go
@@ -19,34 +19,34 @@ func TestPingRoots(t *testing.T) {
 	img := images.NewImage()
 	defer img.Destroy()
 	t0 := time.Now()
-	err = is.searchRoots("testimages/loadimage/test.jpg", img)
+	err = is.searchRoots("testimages/loadimage/22.jpg", img)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t1 := time.Now().Sub(t0)
-	
+
 	img = images.NewImage()
 	defer img.Destroy()
 	t0 = time.Now()
-	err = is.pingRoots("testimages/loadimage/test.jpg", img)
+	err = is.pingRoots("testimages/loadimage/22.jpg", img)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t2 := time.Now().Sub(t0)
-	
+
 	img = images.NewImage()
 	defer img.Destroy()
 	t0 = time.Now()
-	err = is.searchRoots("testimages/loadimage/test.jpg", img)
+	err = is.searchRoots("testimages/loadimage/22.jpg", img)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t3 := time.Now().Sub(t0)
-	
+
 	if t1 < t2 {
 		t.Fatal(fmt.Sprintf("pingRoots is slower than searchRoots! pingRoots: %v, searchRoots: %v", t2, t1))
 	}
-	
+
 	if t3 < t2 {
 		t.Fatal(fmt.Sprintf("pingRoots is slower than searchRoots! pingRoots: %v, searchRoots: %v", t2, t3))
 	}


### PR DESCRIPTION
When using small images (320 x 181, 29 KB), FromFile might be faster than PingImage which causes the test to fail sometimes. Using larger test image should mitigate random factors in the test and ensure that PingImage is faster.