### PR TITLE
Enable webroots

### DIFF
--- a/server/ops/roots.go
+++ b/server/ops/roots.go
@@ -12,16 +12,23 @@ var (
 
 type roots []string
 
-func (roots *roots) Add(n string) error {
-	logging.Debug("Adding root: " + n)
-	for _, path := range *roots {
-		if path == n {
-			return ErrRootAlreadyAdded
-		}
+func (roots *roots) Add(r string) error {
+	logging.Debug("Adding root: " + r)
+	if roots.HasRoot(r) {
+		return ErrRootAlreadyAdded
 	}
 
-	*roots = append(*roots, n)
+	*roots = append(*roots, r)
 	return nil
+}
+
+func (roots *roots) HasRoot(r string) bool {
+	for _, path := range *roots {
+		if path == r {
+			return true
+		}
+	}
+	return false
 }
 
 func (roots *roots) Remove(r string) error {

--- a/server/urlparser.go
+++ b/server/urlparser.go
@@ -191,7 +191,7 @@ const (
 // returns validated parameters from request and error if invalid
 func getParams(a *fasthttp.Args) (w, h, cropx, cropy int, mode mode, format, url string, err error) {
 
-	if strings.Contains(a.String(), "%3F") {
+	if strings.Contains(a.String(), "%3F") { // %3F = ?
 		err = errors.New("Invalid characters in request!")
 		return
 	}

--- a/server/urlparser.go
+++ b/server/urlparser.go
@@ -11,9 +11,13 @@ import (
 func ParseURI(uri *fasthttp.URI, source ops.ImageSource, marker ops.Watermarker) (operations []ops.Operation, format string, err, invalid error) {
 	filename := string(uri.Path())
 
-	w, h, cropx, cropy, mode, format, invalid := getParams(uri.QueryArgs())
+	w, h, cropx, cropy, mode, format, url, invalid := getParams(uri.QueryArgs())
 	if invalid != nil {
 		return
+	}
+
+	if url != "" {
+		source.AddRoot(url)
 	}
 
 	ow, oh, err := source.ImageSize(filename)
@@ -181,11 +185,13 @@ const (
 	formatParam = "format"
 	cropxParam  = "cropx"
 	cropyParam  = "cropy"
+	urlParam		= "url"
 )
 
 // returns validated parameters from request and error if invalid
-func getParams(a *fasthttp.Args) (w, h, cropx, cropy int, mode mode, format string, err error) {
-	if strings.Contains(a.String(), "%") {
+func getParams(a *fasthttp.Args) (w, h, cropx, cropy int, mode mode, format, url string, err error) {
+
+	if strings.Contains(a.String(), "%3F") {
 		err = errors.New("Invalid characters in request!")
 		return
 	}
@@ -216,12 +222,16 @@ func getParams(a *fasthttp.Args) (w, h, cropx, cropy int, mode mode, format stri
 	// TODO: verify that the format is one we support.
 	// We do not want to support TXT, for instance
 
+	url = string(a.Peek(urlParam))
+
 	a.Del(widthParam)
 	a.Del(heightParam)
 	a.Del(modeParam)
 	a.Del(formatParam)
 	a.Del(cropxParam)
 	a.Del(cropyParam)
+	a.Del(urlParam)
+
 	if a.Len() != 0 {
 		err = errors.New("Invalid parameter " + a.String())
 		return

--- a/server/urlparser.go
+++ b/server/urlparser.go
@@ -185,7 +185,7 @@ const (
 	formatParam = "format"
 	cropxParam  = "cropx"
 	cropyParam  = "cropy"
-	urlParam		= "url"
+	urlParam    = "url"
 )
 
 // returns validated parameters from request and error if invalid


### PR DESCRIPTION
RIC server can now serve images from web roots. Webroots are added in query parameters as "url=http://example.com" when requesting images. RIC automatically adds new webroots to its list of roots.